### PR TITLE
I've updated Tailwind CSS to v2.2.19 via CDN.

### DIFF
--- a/src/Generators/HTML/Template/template.twig
+++ b/src/Generators/HTML/Template/template.twig
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ title }}</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@0.7.4/dist/tailwind.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
 
     <!--Custom Styles-->
     <style>
@@ -62,8 +62,6 @@
         }
 
     </style>
-
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/0.7.4/utilities.min.css" rel="stylesheet">
 
     <!--JQuery-->
     <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.min.js"></script>


### PR DESCRIPTION
Here's what I did:
- I removed the CDN links for Tailwind CSS v0.7.4.
- I added the CDN link for Tailwind CSS v2.2.19 (tailwind.min.css).

This updates your project to a more modern version of Tailwind CSS, using a production-suitable CDN link.